### PR TITLE
Shared compression is similar, but risks are different

### DIFF
--- a/draft-thomson-escape-report.md
+++ b/draft-thomson-escape-report.md
@@ -723,11 +723,12 @@ The discussion pointed out that these concerns are not new or uniquely enabled
 by Web Packaging. However, it was pointed out that new features are routinely
 subject to higher security and privacy expectations. In an example unrelated to
 Web Packaging but with similar tradeoffs, shared compression of multiple
-resources has significant performance benefits but comes with a risk of exposing
-encrypted information through side-channels.  Though it is possible that sites
-can use shared compression without this exposure, shared compression will likely
-only be enabled once it is clear that measures to prevent accidental information
-exposure are understood to be effective in a broad set of deployments.
+resources has significant performance benefits. The risk with shared compression
+exposes is the potential for exposing encrypted information through
+side-channels. Though sites can use shared compression without this exposure,
+shared compression will likely only be enabled once it is clear that measures to
+prevent accidental information exposure are understood to be effective in a
+broad set of deployments.
 
 <!-- alternative: For instance, though fingerprinting of browsers might be
 effective based on a range of existing features, the existence of an exposure


### PR DESCRIPTION
The language here might have been read to imply that the risks of shared
compression apply to Web Packaging.  This rewords that to (hopefully)
remove that implication.

@jyasskin does this make the text clearer?